### PR TITLE
Only process successful github calls

### DIFF
--- a/circleci/test_github.py
+++ b/circleci/test_github.py
@@ -20,6 +20,10 @@ class TestGithub(unittest.TestCase):
 
 class TestGithubPullRequest(unittest.TestCase):
     class PullRequestGetMock():
+        def __init__(self):
+            self.status_code = 200
+            self.text = '{}'
+
         def json(self):
             return json.loads(r'''{
   "body": "```\r\npull_requests:\r\n  - https://github.com/octocat/Hello-world/pull/123\r\n```",
@@ -97,7 +101,11 @@ class TestGithubPullRequest(unittest.TestCase):
 class TestGithubStatus(unittest.TestCase):
     class RequestMock():
         def __init__(self):
+            self.status_code = 200
             self.text = '{}'
+
+        def json(self):
+            return {}
 
     def setUp(self):
         os.environ['GH_OAUTH_TOKEN'] = 'GH_TOKEN'
@@ -115,7 +123,7 @@ class TestGithubStatus(unittest.TestCase):
     def test_headers(self):
         pr = GithubStatus()
         self.assertEqual(
-            pr.headers(),
+            pr.headers,
             {
                 'Authorization': 'token GH_TOKEN',
                 'Content-Type': 'application/json'

--- a/circleci/test_integration.py
+++ b/circleci/test_integration.py
@@ -16,6 +16,9 @@ class TestIntegration(unittest.TestCase):
         os.environ['CIRCLE_PULL_REQUEST'] = 'https://github.com/nanliu/circleci/pull/32'
 
     class PullRequestGetMock():
+        def __init__(self):
+            self.status_code = 200
+
         def json(self):
             pull_request_response_example = r'''{
   "body": "```\r\npull_requests:\r\n  - https://github.com/octocat/Hello-world/pull/123\r\n```",

--- a/integration/test_github_status.py
+++ b/integration/test_github_status.py
@@ -3,6 +3,7 @@ import subprocess
 import unittest
 from circleci.github import GithubStatus
 
+
 class TestCircleCIGHStatus(unittest.TestCase):
 
     def change_status_and_assert_change(
@@ -10,7 +11,7 @@ class TestCircleCIGHStatus(unittest.TestCase):
             ref,
             state,
             desc='test_desc',
-            target_url = 'http://target_url',
+            target_url='http://target_url',
             ):
         url1 = 'https://api.github.com/repos/nanliu/circleci/statuses/{}'.format(ref)
         url2 = 'https://api.github.com/repos/nanliu/circleci/commits/{}/status'.format(ref)


### PR DESCRIPTION
We should only process github calls with successful return codes,
otherwise we should print the message we get back. This should provide
more meaningful errors v.s. stack traces.